### PR TITLE
Validate max workers count

### DIFF
--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -1054,6 +1054,85 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 				Expect(errorList).To(HaveLen(0))
 			})
+
+			Context("Worker nodes max count validation", func() {
+				var (
+					worker1 = worker.DeepCopy()
+					worker2 = worker.DeepCopy()
+				)
+				worker1.Name = "worker1"
+				worker2.Name = "worker2"
+
+				It("should allow valid total number of worker nodes", func() {
+					shoot.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize = pointer.Int32(24)
+					shoot.Spec.Networking.Pods = pointer.String("100.96.0.0/20")
+					worker1.Maximum = 4
+					worker2.Maximum = 4
+
+					shoot.Spec.Provider.Workers = []core.Worker{
+						*worker1,
+						*worker2,
+					}
+
+					errorList := ValidateShoot(shoot)
+
+					Expect(errorList).To(BeEmpty())
+				})
+
+				It("should allow valid total number of worker nodes", func() {
+					shoot.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize = pointer.Int32(24)
+					shoot.Spec.Networking.Pods = pointer.String("100.96.0.0/16")
+					worker1.Maximum = 127
+					worker2.Maximum = 127
+
+					shoot.Spec.Provider.Workers = []core.Worker{
+						*worker1,
+						*worker2,
+					}
+
+					errorList := ValidateShoot(shoot)
+
+					Expect(errorList).To(BeEmpty())
+				})
+
+				It("should not allow invalid total number of worker nodes", func() {
+					shoot.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize = pointer.Int32(24)
+					shoot.Spec.Networking.Pods = pointer.String("100.96.0.0/20")
+					worker1.Maximum = 16
+					worker2.Maximum = 16
+
+					shoot.Spec.Provider.Workers = []core.Worker{
+						*worker1,
+						*worker2,
+					}
+
+					errorList := ValidateShoot(shoot)
+
+					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.provider.workers"),
+					}))))
+				})
+
+				It("should not allow ivalid total number of worker nodes", func() {
+					shoot.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize = pointer.Int32(24)
+					shoot.Spec.Networking.Pods = pointer.String("100.96.0.0/16")
+					worker1.Maximum = 128
+					worker2.Maximum = 127
+
+					shoot.Spec.Provider.Workers = []core.Worker{
+						*worker1,
+						*worker2,
+					}
+
+					errorList := ValidateShoot(shoot)
+
+					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.provider.workers"),
+					}))))
+				})
+			})
 		})
 
 		Context("dns section", func() {
@@ -1720,11 +1799,13 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
 					"Field": Equal("spec.kubernetes.kubeControllerManager.nodeCIDRMaskSize"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.kubernetes.kubeControllerManager.nodeCIDRMaskSize"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.provider.workers"),
 				})),
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeInvalid),
-						"Field": Equal("spec.kubernetes.kubeControllerManager.nodeCIDRMaskSize"),
-					})),
 				))
 			})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking ops-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR introduces a validation for maximum workers count in a Shoot cluster.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
